### PR TITLE
Centralize agent configuration

### DIFF
--- a/agent_config.json
+++ b/agent_config.json
@@ -1,0 +1,20 @@
+{
+  "discoverer": {
+    "sqs_queue_url": "https://sqs.localhost.local/discoverer-queue",
+    "migration_table": "PumpSwapMigrationTable",
+    "poll_interval": 60
+  },
+  "analyzer": {
+    "trader_queue_url": "https://sqs.localhost.local/trader-queue",
+    "analysis_table": "PumpSwapAnalysisTable"
+  },
+  "trader": {
+    "mode": "paper",
+    "trader_table_name": "MemecoinSnipingTraderTable"
+  },
+  "optimizer": {
+    "config_bucket": "memecoin-sniping-config-bucket",
+    "config_key": "agent_config.json",
+    "optimizer_table_name": "MemecoinSnipingOptimizerTable"
+  }
+}

--- a/etl/export_trades_to_csv.py
+++ b/etl/export_trades_to_csv.py
@@ -1,0 +1,104 @@
+"""
+Utility script to export historical trades from DynamoDB to a CSV file.
+
+This script can be executed as a standalone module. It reads trades
+from the DynamoDB table defined by the ``TRADER_TABLE_NAME`` environment
+variable (defaults to ``MemecoinSnipingTraderTable``), filters them by a
+``days_back`` window and writes the results to a CSV file. Decimals are
+converted to floats for better compatibility with pandas and other
+analytics tools.
+
+Example usage:
+
+    python export_trades_to_csv.py --days 60 --output trades_60d.csv
+
+In a Lambda context, this script can be imported and the
+``export_trades`` function called directly to produce a CSV in the /tmp
+directory, then uploaded to S3 if desired.
+"""
+from __future__ import annotations
+
+import csv
+import argparse
+import os
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import List, Dict, Any
+
+try:
+    import boto3  # type: ignore
+    from boto3.dynamodb.conditions import Attr  # type: ignore
+except Exception:
+    boto3 = None  # type: ignore
+    Attr = None  # type: ignore
+
+
+def scan_trades(days_back: int = 30) -> List[Dict[str, Any]]:
+    """Retrieve trades from DynamoDB newer than ``days_back`` days.
+
+    Args:
+        days_back: Number of days of history to retrieve.
+
+    Returns:
+        A list of trade dictionaries.
+    """
+    if boto3 is None or Attr is None:
+        raise RuntimeError("boto3 is required for DynamoDB operations")
+
+    table_name = os.environ.get("TRADER_TABLE_NAME", "MemecoinSnipingTraderTable")
+    dynamodb = boto3.resource("dynamodb")  # type: ignore
+    table = dynamodb.Table(table_name)
+    start_date = (datetime.utcnow() - timedelta(days=days_back)).isoformat()
+
+    # Filter expression: entry_time >= :start_date
+    filter_expr = Attr("entry_time").gte(start_date)
+    resp = table.scan(FilterExpression=filter_expr)
+    trades = resp.get("Items", [])
+    # Convert Decimal values to float
+    for trade in trades:
+        for key, value in list(trade.items()):
+            if isinstance(value, Decimal):
+                trade[key] = float(value)
+    return trades
+
+
+def write_csv(trades: List[Dict[str, Any]], output_path: str) -> None:
+    """Write a list of trade dicts to a CSV file.
+
+    Args:
+        trades: List of trade dictionaries.
+        output_path: Destination path for the CSV file.
+    """
+    if not trades:
+        print("No trades to export")
+        return
+    # Determine all keys
+    keys = sorted({key for trade in trades for key in trade.keys()})
+    with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=keys)
+        writer.writeheader()
+        for trade in trades:
+            writer.writerow(trade)
+    print(f"Exported {len(trades)} trades to {output_path}")
+
+
+def export_trades(days_back: int = 30, output_path: str = "trades_export.csv") -> str:
+    """High-level function to export trades to CSV.
+
+    Returns the path to the CSV file.
+    """
+    trades = scan_trades(days_back)
+    write_csv(trades, output_path)
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export trades from DynamoDB to CSV")
+    parser.add_argument("--days", type=int, default=30, help="Number of days of history to export")
+    parser.add_argument("--output", type=str, default="trades_export.csv", help="Output CSV filename")
+    args = parser.parse_args()
+    export_trades(args.days, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,0 +1,108 @@
+"""Common utilities for loading configuration values.
+
+This module centralizes the logic for retrieving configuration parameters for
+the memecoin sniping project.  Instead of reading environment variables
+directly throughout the code, agents can call ``load_config`` once at
+startup.  The configuration file can be stored locally or in S3.  When
+executed in AWS Lambda, the function attempts to download the configuration
+JSON from S3 (bucket/key defined by ``CONFIG_BUCKET`` and ``CONFIG_KEY``
+environment variables).  If those variables are not set or boto3 is
+unavailable, the function falls back to reading a ``agent_config.json``
+file in the same directory.
+
+Usage:
+
+    from common.config import load_config
+
+    config = load_config()
+    sqs_queue_url = config["discoverer"]["sqs_queue_url"]
+
+The returned object is a Python dict loaded from JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import logging
+from typing import Any, Dict
+
+try:
+    import boto3  # type: ignore
+except Exception:  # pragma: no cover
+    boto3 = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def _load_local_config(path: str) -> Dict[str, Any]:
+    """Load configuration from a local JSON file.
+
+    Args:
+        path: Path to a JSON configuration file.
+
+    Returns:
+        Parsed configuration as a dict.  If the file does not exist or
+        cannot be parsed, an empty dict is returned and a warning is
+        logged.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        logger.warning("Configuration file %s not found; using defaults", path)
+    except Exception as exc:  # pragma: no cover
+        logger.error("Failed to load config from %s: %s", path, exc)
+    return {}
+
+
+def _load_s3_config(bucket: str, key: str) -> Dict[str, Any]:
+    """Load configuration from an S3 object.
+
+    Args:
+        bucket: Name of the S3 bucket.
+        key: Key of the object containing the JSON configuration.
+
+    Returns:
+        Parsed configuration dict.  If boto3 is unavailable or any error
+        occurs, an empty dict is returned.
+    """
+    if boto3 is None:
+        logger.info("boto3 unavailable; cannot load config from S3")
+        return {}
+    s3 = boto3.client("s3")  # type: ignore
+    try:
+        response = s3.get_object(Bucket=bucket, Key=key)
+        body = response["Body"].read().decode("utf-8")
+        return json.loads(body)
+    except Exception as exc:  # pragma: no cover
+        logger.error("Failed to load config from s3://%s/%s: %s", bucket, key, exc)
+        return {}
+
+
+def load_config() -> Dict[str, Any]:
+    """Return the merged configuration.
+
+    The function first checks whether ``CONFIG_BUCKET`` and ``CONFIG_KEY``
+    environment variables are set.  If so, it attempts to load the JSON
+    config from S3.  Then it loads a local ``agent_config.json`` file from
+    the current directory and merges the two dictionaries (local values
+    override remote values).  If neither source yields data, an empty
+    dict is returned.
+
+    Returns:
+        Configuration dictionary.
+    """
+    config: Dict[str, Any] = {}
+    bucket = os.environ.get("CONFIG_BUCKET")
+    key = os.environ.get("CONFIG_KEY")
+    if bucket and key:
+        config.update(_load_s3_config(bucket, key))
+    # local override
+    # configuration file lives at the repository root
+    config_path = os.path.join(
+        os.path.dirname(__file__), os.pardir, os.pardir, "agent_config.json"
+    )
+    config.update(_load_local_config(os.path.abspath(config_path)))
+    return config

--- a/src/discoverer/discoverer.py
+++ b/src/discoverer/discoverer.py
@@ -1,0 +1,122 @@
+"""
+Improved Discoverer agent for PumpSwap migrations.
+
+This version illustrates how to centralize configuration via the
+``common.config`` module and provides stubs for ``periodic_discovery``
+and ``process_webhook`` that can be filled in with real logic.  It
+demonstrates reading the SQS queue URL from the configuration file
+instead of relying solely on environment variables.
+"""
+
+import json
+import logging
+import asyncio
+from typing import Dict, List, Optional
+
+import boto3
+import aiohttp
+from datetime import datetime, timedelta
+
+from botocore.exceptions import ClientError, NoCredentialsError  # type: ignore
+
+from common.config import load_config
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Load configuration once at module import
+CONFIG = load_config()
+
+# Read SQS queue URL and table name from the loaded config; fallback to env vars
+SQS_QUEUE_URL: str = CONFIG.get("discoverer", {}).get("sqs_queue_url") or \
+    boto3.client("sqs").get_queue_url(QueueName="DiscovererQueue")["QueueUrl"]
+MIGRATION_TRACKING_TABLE: str = CONFIG.get("discoverer", {}).get("migration_table", "PumpSwapMigrationTable")
+
+
+class PumpSwapDiscoverer:
+    """Discoverer class that uses the config system.
+
+    This implementation focuses on PumpSwap migrations.  For brevity,
+    only a subset of the full logic is shown; see the original code in
+    the repository for complete API calls.
+    """
+
+    def __init__(self, sqs_client, secrets_manager_client, dynamodb_resource):
+        self.sqs = sqs_client
+        self.secrets_manager = secrets_manager_client
+        self.table = dynamodb_resource.Table(MIGRATION_TRACKING_TABLE)
+        self.session = aiohttp.ClientSession()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.session.close()
+
+    def send_to_sqs(self, message: Dict[str, any]) -> None:
+        """Send a discovery message to the configured SQS queue."""
+        try:
+            self.sqs.send_message(QueueUrl=SQS_QUEUE_URL, MessageBody=json.dumps(message))
+            logger.info("Sent migration message to SQS")
+        except Exception as exc:
+            logger.error("Failed to send message to SQS: %s", exc)
+
+    async def discover_pumpswap_migrations(self) -> List[Dict[str, any]]:
+        """Placeholder for the migration discovery logic.
+
+        Returns a list of mock migrations for demonstration purposes.
+        """
+        # TODO: implement real API calls to Moralis/BitQuery/Shyft
+        await asyncio.sleep(0.1)  # simulate network delay
+        return [
+            {
+                "token_address": "mock_token",
+                "graduation_timestamp": datetime.utcnow().isoformat(),
+                "first_trade_timestamp": datetime.utcnow().isoformat(),
+                "market_cap_at_graduation": 100_000,
+                "liquidity_at_graduation": 10_000,
+                "total_volume_usd": 5_000,
+                "trade_count": 20,
+            }
+        ]
+
+    async def periodic_discovery(self) -> None:
+        """Periodically poll for new migrations and send them to SQS."""
+        logger.info("Starting periodic discovery loop")
+        while True:
+            migrations = await self.discover_pumpswap_migrations()
+            for mig in migrations:
+                self.send_to_sqs(mig)
+            # sleep for a configured interval (default 60s)
+            await asyncio.sleep(CONFIG.get("discoverer", {}).get("poll_interval", 60))
+
+    def process_webhook(self, webhook_data: Dict[str, any]) -> None:
+        """Process a webhook from an external service.
+
+        In a production system this method would parse the webhook body,
+        validate it and push relevant events to SQS.  Here it just logs
+        the call for demonstration.
+        """
+        logger.info("Received webhook: %s", webhook_data)
+        # TODO: implement webhook parsing and push to SQS
+
+
+async def lambda_handler(event, context):
+    """Entry point for the Lambda.
+
+    This handler demonstrates how to run the discovery logic and send
+    messages to SQS using the central configuration.  When executed in
+    AWS, the runtime will inject ``event`` and ``context`` automatically.
+    """
+    try:
+        sqs_client = boto3.client("sqs")
+        secrets = boto3.client("secretsmanager")
+        dynamodb = boto3.resource("dynamodb")
+        async with PumpSwapDiscoverer(sqs_client, secrets, dynamodb) as discoverer:
+            migrations = await discoverer.discover_pumpswap_migrations()
+            for mig in migrations:
+                discoverer.send_to_sqs(mig)
+        return {"statusCode": 200, "body": json.dumps({"migrations": len(migrations)})}
+    except Exception as exc:
+        logger.error("Unhandled error: %s", exc)
+        return {"statusCode": 500, "body": json.dumps({"error": str(exc)})}


### PR DESCRIPTION
## Summary
- add a single `agent_config.json` at repo root
- look for this config in `common.config`
- provide minimal modules extracted from the archive

## Testing
- `pytest -q memecoin_sniping_solution_updated\ \(2\)/dashboard/test_dashboard.py::test_dashboard_routes` *(fails: module 'routes' has no attribute 'trading')*

------
https://chatgpt.com/codex/tasks/task_e_6882723606e48322acb396f44ac38be7